### PR TITLE
iCloud Photo Library

### DIFF
--- a/photo_stream_backup.rb
+++ b/photo_stream_backup.rb
@@ -8,7 +8,7 @@ class PhotoStreamBackUpper
   require 'shellwords'
   require 'sqlite3'
 
-  PHOTO_STREAM_DIR="#{ENV['HOME']}/Library/Application Support/iLifeAssetManagement"
+  PHOTO_STREAM_DIR="#{ENV['HOME']}/Library/Containers/com.apple.cloudphotosd/Data/Library/Application Support/com.apple.cloudphotosd/services/com.apple.photo.icloud.sharedstreams"
 
   def initialize(streams, destination, verbose = false)
     raise ArgumentError, "Unable to read destination directory" unless File.readable? File.expand_path(destination)
@@ -30,7 +30,7 @@ class PhotoStreamBackUpper
   def get_ps_db_file
     return @ps_sql_file if @ps_sql_file
 
-    share_dir = "#{PHOTO_STREAM_DIR}/state/albumshare/"
+    share_dir = "#{PHOTO_STREAM_DIR}/coremediastream-state/"
 
     # Probably a lazy way to do this with the .last method, but all 
     # you should ever get out of this query is ['.', '..', interesting_dir]

--- a/photo_stream_backup.rb
+++ b/photo_stream_backup.rb
@@ -73,6 +73,15 @@ class PhotoStreamBackUpper
     results = @db.execute(sql).flatten
   end
 
+  def get_ps_album_uuid(stream_name)
+    sql ="SELECT a.GUID AS 'uuid'
+              FROM Albums AS a
+              WHERE a.name = '#{stream_name}';"
+
+    get_db_conn
+    results = @db.execute(sql).flatten.at(0)
+  end
+
   def backup_image(source, dest)
     # Pretty vanilla rsync here, additional --update option added to only copy
     # over files that have changes/are new
@@ -96,11 +105,13 @@ class PhotoStreamBackUpper
 
       FileUtils::mkdir_p "#{@destination}/#{stream}"
 
+      stream_id = get_ps_album_uuid(stream)
+
       ids = get_ps_img_uuids(stream)
 
       puts "Backing up #{ids.size} images..."
       ids.each do |id|
-        source_file = Shellwords.escape("#{PHOTO_STREAM_DIR}/assets/sub-shared/#{id}/IMG_") + '*'
+        source_file = Shellwords.escape("#{PHOTO_STREAM_DIR}/assets/#{stream_id}/#{id}/IMG_") + '*'
         dest_file = Shellwords.escape("#{@destination}/#{stream}/")
         puts "Backing up source file #{source_file} to #{dest_file}" if @verbose
         backup_image(source_file, dest_file)

--- a/photo_stream_backup.rb
+++ b/photo_stream_backup.rb
@@ -64,13 +64,13 @@ class PhotoStreamBackUpper
   end
 
   def get_ps_img_uuids(stream_name)
-    sql ="SELECT ac.GUID AS 'uuid'
-              FROM AssetCollections AS ac 
-                JOIN Albums AS a ON a.GUID = ac.albumGUID 
+    sql ="SELECT ac.GUID AS 'uuid', ac.photoDate AS 'date'
+              FROM AssetCollections AS ac
+                JOIN Albums AS a ON a.GUID = ac.albumGUID
               WHERE a.name = '#{stream_name}';"
 
     get_db_conn
-    results = @db.execute(sql).flatten
+    results = @db.execute(sql)
   end
 
   def get_ps_album_uuid(stream_name)
@@ -111,8 +111,8 @@ class PhotoStreamBackUpper
 
       puts "Backing up #{ids.size} images..."
       ids.each do |id|
-        source_file = Shellwords.escape("#{PHOTO_STREAM_DIR}/assets/#{stream_id}/#{id}/IMG_") + '*'
-        dest_file = Shellwords.escape("#{@destination}/#{stream}/")
+        source_file = Shellwords.escape("#{PHOTO_STREAM_DIR}/assets/#{stream_id}/#{id[0]}/IMG_") + '*'
+        dest_file = Shellwords.escape("#{@destination}/#{stream}/#{id[1]}.jpg")
         puts "Backing up source file #{source_file} to #{dest_file}" if @verbose
         backup_image(source_file, dest_file)
       end


### PR DESCRIPTION
These tweaks made it work for the new location of Shared Photo Streams after migrating to iCloud Photo Library. Probably this should be conditional so it works with either location. There is probably also a more Ruby way of doing all of this, so this might be more of an inspiration request than a pull, since I don't know Ruby :o).

I also pulled the date column to have the destination folder sorted by date; I'm not sure what the underlying date format is though. It's the same order of magnitude as seconds since Jan 1st, 2000 but not quite right. It's definitely not Julian days, which the sqlite docs suggest is the format for a REAL date column.
